### PR TITLE
change FIRST to first

### DIFF
--- a/code-of-conduct.html
+++ b/code-of-conduct.html
@@ -164,7 +164,7 @@
           <div class="col-lg-3 col-md-6 footer-info">
             <img src="assets/img/logo.gif" alt="logo" style="width: 300px; height: 130px;">
             <p>PyCon Uganda is one of the Python Conferences you can attend in East Africa. We shall talk about Python applications in data, web and other domains. This is a platform where Python users, developers, library developers and companies that use Python come together.
-              This is going to be the FIRST PyCon Conference in Uganda!</p>
+              This is going to be the <b>first</b> PyCon Conference in Uganda!</p>
           </div>
 
           <div class="col-lg-3 col-md-6 footer-links">

--- a/index.html
+++ b/index.html
@@ -76,7 +76,7 @@
           <div class="col-lg-6">
             <h2>About The Conference</h2>
             <p>PyCon Uganda is one of the Python Conferences you can attend in East Africa. We shall talk about Python applications in data, web and other domains. This is a platform where Python users, developers, library developers and companies that use Python come together.
-              This is going to be the FIRST PyCon Conference in Uganda!</p>
+              This is going to be the <b>first</b> PyCon Conference in Uganda!</p>
             </p>
           </div>
           <div class="col-lg-3">
@@ -894,7 +894,7 @@
           <div class="col-lg-3 col-md-6 footer-info">
             <img src="assets/img/logo.gif" alt="logo">
             <p>PyCon Uganda is one of the Python Conferences you can attend in East Africa. We shall talk about Python applications in data, web and other domains. This is a platform where Python users, developers, library developers and companies that use Python come together.
-              This is going to be the FIRST PyCon Conference in Uganda!</p>
+              This is going to be the <b>first</b> PyCon Conference in Uganda!</p>
           </div>
 
           <div class="col-lg-3 col-md-6 footer-links">


### PR DESCRIPTION
This PR seeks to change `FIRST` keyword to `first` which appears under the description of Pycon

Using `FIRST` gives a totally different convention and breaks consistency of what case type is being used. Therefore i think making bold and maintaining the same case type would give it more emphasis 