### PR TITLE
Remove Location dummy text and update event date

### DIFF
--- a/index.html
+++ b/index.html
@@ -85,7 +85,7 @@
           </div>
           <div class="col-lg-3">
             <h3>When</h3>
-            <p>Thursday to Saturday<br>21-24 September</p>
+            <p>Thursday to Saturday<br>21-23 September</p>
           </div>
         </div>
       </div>

--- a/index.html
+++ b/index.html
@@ -913,7 +913,7 @@
           <div class="col-lg-3 col-md-6 footer-contact">
             <h4>Contact Us</h4>
             <p>
-              <strong>Location:</strong> Kampala Uganda<br>
+              <strong>Location:</strong> Kampala, Uganda<br>
               <strong>Phone:</strong> +256 777 111 111<br>
               <strong>Email:</strong> pyconug@pycon.org<br>
             </p>

--- a/index.html
+++ b/index.html
@@ -85,7 +85,7 @@
           </div>
           <div class="col-lg-3">
             <h3>When</h3>
-            <p>Thursday to Saturday<br>21-23 September</p>
+            <p>Thursday to Saturday<br>21-24 September</p>
           </div>
         </div>
       </div>

--- a/index.html
+++ b/index.html
@@ -913,8 +913,7 @@
           <div class="col-lg-3 col-md-6 footer-contact">
             <h4>Contact Us</h4>
             <p>
-              yyyy Street <br>
-              Kampala <br>
+              <strong>Location:</strong> Kampala Uganda<br>
               <strong>Phone:</strong> +256 777 111 111<br>
               <strong>Email:</strong> pyconug@pycon.org<br>
             </p>

--- a/speaker-details.html
+++ b/speaker-details.html
@@ -157,7 +157,7 @@
           <div class="col-lg-3 col-md-6 footer-contact">
             <h4>Contact Us</h4>
             <p>
-              <strong>Location:</strong> Kampala Uganda<br>
+              <strong>Location:</strong> Kampala, Uganda<br>
               <strong>Phone:</strong> +256 777 111 111<br>
               <strong>Email:</strong> pyconug@pycon.org<br>
             </p>

--- a/speaker-details.html
+++ b/speaker-details.html
@@ -157,11 +157,9 @@
           <div class="col-lg-3 col-md-6 footer-contact">
             <h4>Contact Us</h4>
             <p>
-              A108 Adam Street <br>
-              New York, NY 535022<br>
-              United States <br>
-              <strong>Phone:</strong> +1 5589 55488 55<br>
-              <strong>Email:</strong> info@example.com<br>
+              <strong>Location:</strong> Kampala Uganda<br>
+              <strong>Phone:</strong> +256 777 111 111<br>
+              <strong>Email:</strong> pyconug@pycon.org<br>
             </p>
 
             <div class="social-links">


### PR DESCRIPTION
- The footer has `yyy` text for location, this has been updated to `kampala, uganda`
- The updates concept paper states event dates are 21-24 september..this pull request attempts to update this too.

![image](https://user-images.githubusercontent.com/65954740/224269566-4665cb9b-4858-43a3-8d49-91a1d6276f7f.png)
